### PR TITLE
Added file size for packages

### DIFF
--- a/alembic/versions/2cc94456a9f_add_package_file_size.py
+++ b/alembic/versions/2cc94456a9f_add_package_file_size.py
@@ -1,0 +1,21 @@
+"""add package file size
+
+Revision ID: 2cc94456a9f
+Revises: 2b1c28c108e
+Create Date: 2016-07-29 10:25:41.969914
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2cc94456a9f'
+down_revision = '2b1c28c108e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('package', sa.Column('file_size', sa.Integer(), nullable=True))
+
+def downgrade():
+    op.drop_column('package', 'file_size')

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,28 @@
+from flask.ext.script import Manager
+from packages.app import app
+from packages.objects import Package
+from packages.kpack import PackageInfo
+from packages.config import _cfg
+from packages.database import db
+
+import os
+
+manager = Manager(app)
+
+@manager.command
+def calc_package_file_sizes():
+    packages = Package.query.all()
+    for package in packages:
+        path = build_package_path(package)
+        size = PackageInfo.get_file_size(path)
+        package.file_size = size
+    
+    db.commit()
+    return None
+    # update db
+
+def build_package_path(p):
+    return os.path.join(_cfg("storage"), p.repo, "{0}-{1}.pkg".format(p.name, p.version))
+
+if __name__ == "__main__":
+    manager.run() 

--- a/packages/blueprints/api.py
+++ b/packages/blueprints/api.py
@@ -207,6 +207,7 @@ def upload_package():
     package.copyright = info.copyright
     package.capabilities = ' '.join(info.capabilities)
     package.contents = None
+    package.file_size = info.file_size
     package.dependencies = list()
     for dep in info.dependencies:
         try:

--- a/packages/kpack.py
+++ b/packages/kpack.py
@@ -15,8 +15,13 @@ class PackageInfo():
     maintainer = None
     infourl = None
     copyright = None
+    file_size = None
     dependencies = list()
     capabilities = list()
+
+    @staticmethod
+    def get_file_size(path):
+        return os.path.getsize(path)
 
     @staticmethod
     def read_package(path):
@@ -49,6 +54,11 @@ class PackageInfo():
                 result.dependencies = [v.split(':')[0] for v in value.split(' ')]
             elif key == 'capabilities':
                 result.capabilities = value.split(' ')
+        try:
+            result.file_size = PackageInfo.get_file_size(path)
+        except:
+            result.file_size = None
+ 
         return result
 
     @staticmethod

--- a/packages/objects.py
+++ b/packages/objects.py
@@ -69,6 +69,7 @@ class Package(Base):
     infourl = Column(Unicode(1024))
     copyright = Column(Unicode(1024))
     capabilities = Column(Unicode(2048))
+    file_size = Column(Integer)
     dependencies = relationship('Package', 
         secondary=package_dependencies,
         primaryjoin=id==package_dependencies.c.package_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Bcrypt==0.5.2
 Flask-Classy==0.6.3
 Flask-Login==0.2.11
 Flask-Markdown==0.3
+Flask-Script==2.0.3
 Jinja2==2.7
 Mako==0.9.1
 Markdown==2.3.1

--- a/templates/package.html
+++ b/templates/package.html
@@ -157,6 +157,12 @@ document.getElementById("transfer-button").addEventListener('click', function(e)
             <td><a href="{{ package.infourl }}">{{ package.infourl }}</a></td>
         </tr>
         {% endif %}
+        {% if package.file_size %}
+        <tr>
+            <th>File Size</th>
+            <td>{{ '{: n}'.format(package.file_size / 1024) }} KB</td>
+        </tr>
+        {% endif %}
         <tr>
             <th>Downloads</th>
             <td>{{ package.downloads }} </td>


### PR DESCRIPTION
PR to address: https://github.com/KnightOS/KnightOS/issues/305

A couple notes:
- Added a new column to the package table for tracking the number of bytes. Therefore the db needs to be migrated.
- New and version bumped package uploads have their file size calculated on upload.
- All existing packages can have their file sizes calculated and saved in the db by running<br/>
  `python manage.py calc_package_file_sizes`
- Accordingly, I added a new dependency flask-script in order to do so (therefore updating w/ pip may be in order).
- The file size is saved in bytes and displayed as KB. KB seemed to be the best fit based on the packages I looked at.
